### PR TITLE
Add support for pug file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ console.log(res)
 - Objective C
 - Perl
 - PHP
+- Pug
 - Python
 - Ruby
 - Rust

--- a/src/file-extensions.ts
+++ b/src/file-extensions.ts
@@ -156,6 +156,10 @@ const extensions: FileExtension[] = [
     comments: cStyleComments,
   },
   {
+    lang: 'pug',
+    comments: { line: '//', block: null },
+  },
+  {
     lang: 'py',
     comments: { line: '#', block: { start: '"""', end: '"""' } },
   },


### PR DESCRIPTION
Jade was renamed to pug and so the file extension changed to .pug

This pull request allows .pug files to be used as well